### PR TITLE
Added --area (-a) for targeting exclusive scene calls

### DIFF
--- a/ultrasync/cli.py
+++ b/ultrasync/cli.py
@@ -95,6 +95,10 @@ def print_version_msg():
               help='Specify the alarm scene to change to. Possible values '
               'are "{}", and "{}".'.format(
                   '", "'.join(ALARM_SCENES[:-1]), ALARM_SCENES[-1]))
+@click.option('--area', '-a', default=0, type=int, metavar='AREA',
+              help='Specify the Area you wish to target with a --scene (-s) '
+              'action. If no area is specified, then *all* areas are '
+              'targeted.')
 @click.option('--full-debug-dump', is_flag=True,
               help='Dump a full set of tracing files to a archive for '
               'comparison/debug purposes. Usually the --debug-dump is '
@@ -106,7 +110,7 @@ def print_version_msg():
 @click.option('--version', '-V', is_flag=True,
               help='Display the version of the ultrasync library and exit.')
 def main(config, debug_dump, full_debug_dump, scene, details, watch,
-         verbose, version):
+         area, verbose, version):
     """
     Wrapper to ultrasync library.
     """
@@ -183,12 +187,19 @@ def main(config, debug_dump, full_debug_dump, scene, details, watch,
             actioned = True
 
     if scene:
-        if not usync.set(state=scene):
-            # Failed to set scene
-            logger.error(
-                'Could not load set scene to: {}'.format(scene))
+        areas = [area] if area else [int(a) for a in self.area.keys()]
+        has_error = False
+        for area in areas:
+            if not usync.set(scene=scene, area=area):
+                # Failed to set scene
+                logger.error(
+                    'Could not load set scene to {} in Area {}'.format(
+                        scene, area))
+                has_error = True
+            actioned = True
+
+        if has_error:
             sys.exit(1)
-        actioned = True
 
     if watch:
         area_delta = {}

--- a/ultrasync/cli.py
+++ b/ultrasync/cli.py
@@ -187,19 +187,9 @@ def main(config, debug_dump, full_debug_dump, scene, details, watch,
             actioned = True
 
     if scene:
-        areas = [area] if area else [int(a) for a in self.area.keys()]
-        has_error = False
-        for area in areas:
-            if not usync.set(scene=scene, area=area):
-                # Failed to set scene
-                logger.error(
-                    'Could not load set scene to {} in Area {}'.format(
-                        scene, area))
-                has_error = True
-            actioned = True
-
-        if has_error:
+        if not usync.set_scene(areas=area, scene=scene):
             sys.exit(1)
+        actioned = True
 
     if watch:
         area_delta = {}

--- a/ultrasync/main.py
+++ b/ultrasync/main.py
@@ -409,7 +409,7 @@ class UltraSync(UltraSyncConfig):
         progress.update(100.001 - progress_track)
         return
 
-    def set(self, area=1, state=AlarmScene.DISARMED):
+    def set(self, area=1, scene=AlarmScene.DISARMED):
         """
         Sets Alarm Scene
 
@@ -417,7 +417,14 @@ class UltraSync(UltraSyncConfig):
         if not self.session_id and not self.login():
             return False
 
-        if state not in ALARM_SCENES:
+        if scene not in ALARM_SCENES:
+            logger.error(
+                '{} is not valid alarm scene'.format(scene))
+            return False
+
+        if str(area) not in self.areas:
+            logger.error(
+                'Area {} does not exist'.format(area))
             return False
 
         # Start our payload off with our session identifier
@@ -431,12 +438,12 @@ class UltraSync(UltraSyncConfig):
                 'mask': 1 << (area - 1) % 8,
             })
 
-            if state == AlarmScene.STAY:
+            if scene == AlarmScene.STAY:
                 payload.update({
                     'fnum': ZWPanelFunction.AREA_STAY,
                 })
 
-            elif state == AlarmScene.AWAY:
+            elif scene == AlarmScene.AWAY:
                 payload.update({
                     'fnum': ZWPanelFunction.AREA_AWAY,
                 })
@@ -456,12 +463,12 @@ class UltraSync(UltraSyncConfig):
                 'data1': 1 << (area - 1) % 8,
             })
 
-            if state == AlarmScene.STAY:
+            if scene == AlarmScene.STAY:
                 payload.update({
                     'data2': CNPanelFunction.AREA_STAY,
                 })
 
-            elif state == AlarmScene.AWAY:
+            elif scene == AlarmScene.AWAY:
                 payload.update({
                     'data2': CNPanelFunction.AREA_AWAY,
                 })


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

- Those who have multiple Area's defined can exclusively target one from the other with a new `--area` (`-a`) switch.
- If no `--area` is specified on a `--scene` call then all **detected** areas are impacted.

Previous to this commit the `--scene` call exclusively only locked on Area 1.
