### PR TITLE
Drop python v3.7 support as it doesn't bode well with TravisCI right now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ dist: xenial
 
 matrix:
   include:
-    - python: "3.7"
-      env: TOXENV=py37
     - python: "3.8"
       env: TOXENV=py38
-    - python: "3.9-dev"
+    - python: "3.9"
       env: TOXENV=py39
+    - python: "3.10"
+      env: TOXENV=py310
 
 install:
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-dist: xenial
+dist: focal
 
 matrix:
   include:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,coverage-report
+envlist = py38,py39,py310,coverage-report
 
 
 [testenv]
@@ -14,14 +14,6 @@ commands =
     coverage run --parallel -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
-[testenv:py37]
-deps=
-   -r{toxinidir}/requirements.txt
-   -r{toxinidir}/dev-requirements.txt
-commands =
-    coverage run --parallel -m pytest {posargs}
-    flake8 . --count --show-source --statistics
-
 [testenv:py38]
 deps=
    -r{toxinidir}/requirements.txt
@@ -31,6 +23,14 @@ commands =
     flake8 . --count --show-source --statistics
 
 [testenv:py39]
+deps=
+   -r{toxinidir}/requirements.txt
+   -r{toxinidir}/dev-requirements.txt
+commands =
+    coverage run --parallel -m pytest {posargs}
+    flake8 . --count --show-source --statistics
+
+[testenv:py310]
 deps=
    -r{toxinidir}/requirements.txt
    -r{toxinidir}/dev-requirements.txt


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #17
Travis CI isn't taking well to Python 3.7 Testing for some reason... just dropping py37 and adding in py310