### PR TITLE
Zone bypass for ZeroWire

### DIFF
--- a/ultrasync/main.py
+++ b/ultrasync/main.py
@@ -593,7 +593,7 @@ class UltraSync(UltraSyncConfig):
             'sess': self.session_id,
         }
 
-        if self.vendor in (NX595EVendor.XGEN8):
+        if self.vendor in (NX595EVendor.ZEROWIRE, NX595EVendor.XGEN8):
             payload.update({
                 'cmd': 5,
                 'opt': int(state),


### PR DESCRIPTION
## Description:

Zone bypass for ZeroWire works fine with this change.
Things to mention
- the alarm state reports "Sensor bypass" as opposed to Ultrasync app which reports "Ready" if all "Not ready" sensors have been bypassed.
- the only way I found to check if a sensor is bypassed is to look at priority (priority 3 means sensor is bypassed). It would be nice if there would be a "bypassed: true/false" attribute.

<!-- Have anything else to describe? Define it here -->
