### PR TITLE
Solve toggle bypass issue for COMNAV

### DIFF
--- a/ultrasync/main.py
+++ b/ultrasync/main.py
@@ -593,20 +593,26 @@ class UltraSync(UltraSyncConfig):
             'sess': self.session_id,
         }
 
-        if self.vendor in (NX595EVendor.ZEROWIRE, NX595EVendor.XGEN8):
-            payload.update({
+        if self.vendor in (NX595EVendor.XGEN8):
+                payload.update({
                 'cmd': 5,
                 'opt': int(state),
                 'zone': zone - 1,
             })
+            
+                # Send our response
+                response = self.__get(
+                    '/user/zonefunction.cgi', payload=payload)
+
         elif self.vendor in (NX595EVendor.COMNAV):
             # Call comnav_process_zones to update can_bypass attribute
             self.comnav_process_zones
 
             # Get the current can_bypass state of the zone
             can_bypass = self.zones[zone - 1]['can_bypass']
-            # If the current can_bypass state does not match the desired bypass
-            # state, toggle the bypass state
+
+            # If the current can_bypass state does not match the desired bypass state,
+            # toggle the bypass state
             if can_bypass == state:
                 # Start our payload off with our session identifier
                 payload = {
@@ -614,6 +620,13 @@ class UltraSync(UltraSyncConfig):
                     'comm': 82,
                     'data0': zone - 1,
                 }
+            else: 
+                payload = {}
+
+            # Send our response
+            response = self.__get(
+                '/user/zonefunction.cgi', payload=payload)
+ 
         else:   # self.vendor is NX595EVendor.{ZEROWIRE, XGEN}
 
             logger.error(


### PR DESCRIPTION
For COMNAV vendor, both bypass and unbypass services, act as toggles. Furthermore, when 2 or more zones are bypassed, if we call the bypass service in HA for one of the already bypassed zones, it toggles the last zone we have in the payload. This is happening cause, no matter what the result of the check is, it will send the payload, as the response is out of the if statements. Currently, we start the payload, inside we run all the if statements for each each Vendor, and then we send the payload response.

In the case of XGEN8, inside the if statement, we call the payload.update each time, and therefore it is working correctly.  However, in COMNAV, since the payload is the same all the time cause it acts as a toggle, if the can_bypass is equal with the state, then the payload of the zone selected, will be send. If it is not, it will skip the payload and send the last payload response.

The propose changes, put the payload response inside the if statements for each vendor. Thus, for COMNAV, if the zone is already bypassed, it will NOT send the response at all.

The only check that needs to be performed, is for the other vendor, XGEN8, for which i do not have any, to validate the change.

## Description:
**Related issue (if applicable):** #<!--ultrasync issue number goes here-->

<!-- Have anything else to describe? Define it here -->
