### PR TITLE
Fixed Output Control Implementation errors

### DIFF
--- a/ultrasync/main.py
+++ b/ultrasync/main.py
@@ -2124,25 +2124,24 @@ class UltraSync(UltraSyncConfig):
         if not response:
             return False
 
-            # Regex to capture output names and states
-            name_pattern = re.compile(
-                r'var oname(\d) = decodeURIComponent'
-                r'\(decode_utf8\("([^"]*)"\)\);')
-            state_pattern = re.compile(r'var ostate(\d) = "(\d)";')
+        # Regex to capture output names and states
+        name_pattern = re.compile(
+            r'var oname(\d) = decodeURIComponent'
+            r'\(decode_utf8\("([^"]*)"\)\);')
+        state_pattern = re.compile(r'var ostate(\d) = "(\d)";')
 
-            # Extract names and states
-            names = {int(m.group(1)): unquote(m.group(2))
-                     for m in name_pattern.finditer(response)}
-            states = {int(m.group(1)): m.group(2)
-                      for m in state_pattern.finditer(response)}
+        # Extract names and states
+        names = {int(m.group(1)): unquote(m.group(2))
+                for m in name_pattern.finditer(response)}
+        states = {int(m.group(1)): m.group(2)
+                for m in state_pattern.finditer(response)}
 
             # Store our outputs:
-            for i in range(1, max(len(names), len(states)) + 1):
-                self.outputs[i] = {
-                    'name': names.get(i, ''),
-                    'state': states.get(i, '0'),
-                }
-            return False
+        for i in range(1, max(len(names), len(states)) + 1):
+            self.outputs[i] = {
+                'name': names.get(i, ''),
+                'state': states.get(i, '0'),
+            }
 
         return True
 
@@ -2152,14 +2151,14 @@ class UltraSync(UltraSyncConfig):
 
         At this time, this feature is only supported by the COMNAV panels
         """
+        if not self.session_id and not self.login():
+            return False
+
         if self.vendor is not NX595EVendor.COMNAV:
             # Only vendor that supports this right now is COMNAV
             logger.error(
                 'Output control not implemented for vendor {}'.format(
                     self.vendor))
-            return False
-
-        if not self.session_id and not self.login():
             return False
 
         if not isinstance(output, int) or output not in self.outputs.keys():


### PR DESCRIPTION
## Description:

<!-- Have anything else to describe? Define it here -->
The following are corrections in the `output_control` and `set_output_control` functions that fix the following errors:

1. Unable to retrieve outputs on the alarm.
This was due to indentation errors in the function. The `output` array was never populated because the code was indented to execute only if their was no response.

2. Unknown vendor when switching on and off an output
Because the `if` statement that checks the `self.vendor` was executed before the `login()` function was called, the function would always return the following error:
```
2023-08-08 20:35:34,527 - ERROR - Output control not implemented for vendor Unknown
```